### PR TITLE
auto-detect tests directory

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -182,7 +182,7 @@ package_coverage <- function(path = ".", ..., relative_path = FALSE) {
 
   env <- new.env(parent = ns_env)
 
-  testing_dir <- file.path(path, "tests")
+  testing_dir <- test_directory(path)
 
   res <- environment_coverage_(ns_env,
     c(dots(...),

--- a/R/utils.R
+++ b/R/utils.R
@@ -9,3 +9,12 @@
 dots <- function(...) {
   eval(substitute(alist(...)))
 }
+
+test_directory <- function(path) {
+  dir <- file.path(path, "inst", "tests")
+  if (!file.exists(dir)) {
+    dir <- file.path(path, "tests")
+  }
+  dir
+}
+


### PR DESCRIPTION
This allows coverage of older packages using `inst/tests` as well.