### PR TITLE
set_makevars(): Truly unique variable names and acknowledge comments

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -64,6 +64,8 @@ set_makevars <- function(envs) {
   old <- NULL
   if (file.exists(makevars)) {
     lines <- readLines(makevars)
+    lines <- grep("^[[:space:]]*#", lines, value=TRUE, invert=TRUE)
+        print(lines)
     old <- lines
     for (env in names(envs)) {
       loc <- grep(env, lines)

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,7 +64,6 @@ set_makevars <- function(envs) {
   old <- NULL
   if (file.exists(makevars)) {
     lines <- readLines(makevars)
-    lines <- grep("^[[:space:]]*#", lines, value=TRUE, invert=TRUE)
     old <- lines
     for (env in names(envs)) {
       loc <- grep(sprintf("^[[:space:]]*%s[[:space:]]*=", env), lines)

--- a/R/utils.R
+++ b/R/utils.R
@@ -65,10 +65,9 @@ set_makevars <- function(envs) {
   if (file.exists(makevars)) {
     lines <- readLines(makevars)
     lines <- grep("^[[:space:]]*#", lines, value=TRUE, invert=TRUE)
-        print(lines)
     old <- lines
     for (env in names(envs)) {
-      loc <- grep(env, lines)
+      loc <- grep(sprintf("^[[:space:]]*%s[[:space:]]*=", env), lines)
       if (length(loc) == 0) {
         lines <- append(lines, paste(sep = "=", env, envs[env]))
       } else if(length(loc) == 1) {


### PR DESCRIPTION
A ~/.R/Makevars file
```
CFLAGS=-g -O -mtune=native -Wall -Wsign-compare -Wconversion -Wno-sign-compare
FCFLAGS=-g -O -mtune=native
```
would give:
```r
Error in set_makevars(c(CFLAGS = "-g -O0 -fprofile-arcs -ftest-coverage",  :
  Multiple results for CFLAGS found, something is wrong.FALSE
```
because string sequence `CFLAGS` is part of `FCFLAGS`.  Moreover, comments were not acknowledged, e.g.
```
CFLAGS=-g -O -mtune=native -Wall -Wsign-compare -Wconversion -Wno-sign-compare
## CFLAGS=-g -O -mtune=native
```
would give the same error message.

This pull request addresses both issues.