### PR TITLE
BUG FIX: per_line() would choke on functions created by eval(parse(text=...))

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: covr
 Title: Test Coverage for R packages.
-Version: 0.2.0.9000
+Version: 0.2.0.9000-1
 Authors@R: "Jim Hester <james.f.hester@gmail.com> [aut, cre]"
 Description: Compute test coverage statistics for your package and (optionally)
     upload the results to coveralls.

--- a/R/exclusions.R
+++ b/R/exclusions.R
@@ -15,15 +15,41 @@ exclude <- function(coverage, exclusions = NULL, ...) {
 
   excl <- merge_exclusions(source_exclusions, exclusions)
 
+  # Drop non-excludes
+  stopifnot(!any(duplicated(names(excl)))) ## Sanity check
+  excl <- excl[sapply(excl, FUN=length) > 0L]
+
+  str(list(df=df$filename, cov=names(coverage)))
+  stopifnot(all(df$filename, names(coverage)))
+
   to_exclude <- vapply(seq_len(NROW(df)),
     function(i) {
       file <- df[i,"filename"]
-      file %in% names(excl) &&
+      res <- file %in% names(excl) &&
       all(seq(df[i,"first_line"], df[i, "last_line"]) %in% excl[[file]])
+
+      if (file == "R/abort.R") {
+        stopifnot(file %in% names(excl))
+        seq <- seq(df[i,"first_line"], df[i, "last_line"])
+        drop <- all(seq %in% excl[[file]])
+        str(list(df[i,], seq=seq, excl=excl[[file]], drop=drop, res=res))
+        stopifnot(identical(res, drop))
+      }
+
+      res;
   }, logical(1))
 
-  if (any(to_exclude) == TRUE) {
-    coverage <- coverage[-as.numeric(sort(rownames(df)[to_exclude]))]
+  if (any(to_exclude)) {
+      ok <- (df$filename == "R/abort.R")
+      print(df[ok & !to_exclude,])
+      stopifnot(length(coverage) == length(to_exclude))
+      print(grep("R/abort.R", names(coverage), value=TRUE))
+      print(length(coverage))
+      print(sum(to_exclude))
+      print(names(coverage)[to_exclude])
+      coverage <- coverage[!to_exclude]
+      print(grep("R/abort.R", names(coverage), value=TRUE))
+      print(length(coverage))
   }
 
   coverage

--- a/R/trace_calls.R
+++ b/R/trace_calls.R
@@ -99,4 +99,7 @@ clear_counters <- function() {
 key <- function(x) {
   file <- attr(x, "srcfile")$filename %||% "<default>"
   paste(sep = ":", file, paste0(collapse = ":", c(x)))
+  ## See: Issue #24 (and deprecated Pull Request #25)
+  res <- paste(sep = ":", file, paste0(collapse = ":", c(x)))
+  gsub("<text>", ".text.", res, fixed=TRUE)
 }


### PR DESCRIPTION
`coveralls()` and more precisely `per_line()` would throw an error on functions created by `eval(parse(text=...))` and explained in Issue #24.  This pull request works around the problem.