### PR TITLE
readChar(..., useBytes=FALSE) in UTF-8 encodings is not safe

### DIFF
--- a/R/coveralls.R
+++ b/R/coveralls.R
@@ -21,7 +21,7 @@ to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"), servic
 
   sources <- lapply(names(coverages),
     function(x) {
-      readChar(x, file.info(x)$size)
+      readChar(x, file.info(x)$size, useBytes=TRUE)
     })
 
   res <- mapply(


### PR DESCRIPTION
`covr:::to_coveralls()` uses `readChar()` to read all the source code files, with the default `useBytes=FALSE`.  However, it is not safe to use `readChar(..., useBytes=FALSE)` on source code files **iff** the encoding is UTF-8, because **source code comments may contain invalid UTF-8 byte sequences**, e.g. French accents in Latin-9 encodings.  This is ok according to current R standards.  See R-devel thread '[SUGGESTION: Force install.packages() to use ASCII encoding when parse():ing code?](https://stat.ethz.ch/pipermail/r-devel/2014-December/070274.html)' on 2014-12-11 for full details.

REPRODUCIBLE EXAMPLE:
Add a Swedish/German ö (an o with "umlaut") to a source code comment and using Latin-9 file encoding (non-multibyte) as in https://github.com/HenrikBengtsson/rmini/blob/99b93/R/hello.R will cause `readChar(..., useBytes=FALSE)` to choke if `options(encoding="UTF-8")` as seen in Lines 913-919 in https://travis-ci.org/HenrikBengtsson/rmini/builds/46643665.

PATCH:
This pull request simply uses `useBytes=TRUE`, which covers all R code per se, because according to R docs code itself can only be in ASCII (it's only the source code comments that can be of any (mixed?) encoding).  This avoids the problem, cf. https://travis-ci.org/HenrikBengtsson/rmini/builds/46644001.  Not sure where that remaining
```
Warning message:
grepl("\n", lines, fixed = TRUE):
  input string 1 is invalid in this locale
```
originates from, but it is most likely related to the fact that the source code contains invalid byte sequences if parsed as UTF-8.  It could also be from `devtools` or from R itself.  At least it doesn't give an error.

The downside to using `useBytes=TRUE` is multi-byte characters in source code comments may not look as expected over at Coveralls, e.g. https://coveralls.io/files/420031823 compare with https://github.com/HenrikBengtsson/rmini/blob/99b93/R/hello.R.  On the other hand, I don't see another solution to handle the current "fragile" R specs.

