### PR TITLE
Skip primitive functions as alias in package

### DIFF
--- a/R/replace.R
+++ b/R/replace.R
@@ -1,7 +1,7 @@
 #' @useDynLib covr duplicate_
 replacement <- function(name, env = as.environment(-1)) {
   target_value <- get(name, envir = env)
-  if (is.function(target_value)) {
+  if (is.function(target_value) && !is.primitive(target_value)) {
     new_value <- trace_calls(target_value)
     attributes(new_value) <- attributes(target_value)
 


### PR DESCRIPTION
The function check is incomplete. If an internal function of package is merely an alias of a primitive function, for example,

```r
set_names <- `names<-`
```

the function has `NULL` environment (e.g. `class<-` and `names<-`), the `replacement` function will end up with an error:

```
Error in as.function.default(c(value, if (is.null(bd) || is.list(bd)) list(bd) else bd),  : 
  use of NULL environment is defunct
```

Therefore, all primitive functions (or functions with `NULL` environment) should be skipped.