### PR TITLE
BUG FIX: subprocess() did not escape \\ in Windows path in tmp R script.

### DIFF
--- a/R/subprocess.R
+++ b/R/subprocess.R
@@ -49,6 +49,9 @@ fun <- function() {
 environment(fun) <- .env
 fun()",
 tmp_global_env, tmp_exprs, tmp_output, tmp_objs, tmp_calling_env)
+  if (.Platform$OS.type == "windows") {
+    command <- gsub("\\", "/", command, fixed=TRUE)
+  }
 
   writeChar(con = tmp_source, command, eos = NULL)
   output <- try(devtools:::RCMD("BATCH",


### PR DESCRIPTION
`subprocess()` would generate R scripts that are invalid on Windows due to backslashes in temporary pathnames, e.g.
```r
library(methods)
load('C:\Users\hb\AppData\Local\Temp\RtmpqUOxz3\file160c18a84d19')
.exprs <- readRDS('C:\Users\hb\AppData\Local\Temp\RtmpqUOxz3\file160ceb71f94')
fun <- function() {
  .output <- capture.output(
    for(.expr in .exprs) {
      eval(.expr)
    }
  )
  saveRDS(file = 'C:\Users\hb\AppData\Local\Temp\RtmpqUOxz3\file160c348d338a', .output)
  .new_objs <- ls(environment())
  if (length(.new_objs) > 0) {
    save(list = .new_objs, file = 'C:\Users\hb\AppData\Local\Temp\RtmpqUOxz3\file160c176e507e')
  }
  .new_objs
}
.env <- readRDS('C:\Users\hb\AppData\Local\Temp\RtmpqUOxz3\file160c26313981')
environment(fun) <- .env
fun()
```

Here I take the simple approach to fix the problem after the `command` string has been created. The alternative is to escape/translate the backslashes of each path before passing them to `sprintf()`.  I also added the test for Windows to make the code more clear on what's going on.