### PR TITLE
Added support for all Fortran source file extensions starting with f

### DIFF
--- a/R/compiled.R
+++ b/R/compiled.R
@@ -79,8 +79,7 @@ sources <- function(pkg = ".") {
   pkg <- devtools::as.package(pkg)
   srcdir <- file.path(pkg$path, "src")
   dir(srcdir, rex::rex(".",
-                       list("c", except_any_of(".")) %or% 
-                       list("f", except_any_of(".")), end),
+                       list("c", except_any_of(".")) %or% list("f", except_any_of(".")), end),
       recursive = TRUE,
       full.names = TRUE)
 }

--- a/R/compiled.R
+++ b/R/compiled.R
@@ -79,7 +79,8 @@ sources <- function(pkg = ".") {
   pkg <- devtools::as.package(pkg)
   srcdir <- file.path(pkg$path, "src")
   dir(srcdir, rex::rex(".",
-                       list("c", except_any_of(".")) %or% "f", end),
+                       list("c", except_any_of(".")) %or% 
+                       list("f", except_any_of(".")), end),
       recursive = TRUE,
       full.names = TRUE)
 }

--- a/R/covr.R
+++ b/R/covr.R
@@ -112,6 +112,7 @@ package_coverage <- function(path = ".",
     c(CFLAGS = "-g -O0 -fprofile-arcs -ftest-coverage",
       CXXFLAGS = "-g -O0 -fprofile-arcs -ftest-coverage",
       FFLAGS = "-g -O0 -fprofile-arcs -ftest-coverage",
+      FCFLAGS = "-g -O0 -fprofile-arcs -ftest-coverage",
       LDFLAGS = "--coverage")
     )
   on.exit(reset_makevars(), add = TRUE)


### PR DESCRIPTION
I added support for other common Fortran file extensions (previously only `f` was recognized) by modifying `compiled` function so it captures all file extensions starting with `f` (just copied the `c` part) .  I also modified `package_coverage` function by adding `FCFLAGS' for Fortran 9x code. 

This seems to work with KFAS: https://coveralls.io/builds/2032310