### PR TITLE
launch coveralls on unsupported CI-backends

### DIFF
--- a/R/coveralls.R
+++ b/R/coveralls.R
@@ -18,7 +18,9 @@ coveralls <- function(path = ".", repo_token = NULL, ...) {
   httr::content(httr::POST(coveralls_url, body = list(json_file = httr::upload_file(name))))
 }
 
-to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"), service_name = "travis-ci", repo_token = NULL) {
+to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"),
+                         service_name = "travis-ci", repo_token = NULL) {
+
   coverages <- per_line(x)
 
   coverage_names <- names(coverages)

--- a/R/coveralls.R
+++ b/R/coveralls.R
@@ -1,10 +1,14 @@
 #' Run covr on a package and upload the result to coveralls
 #' @param path file path to the package
+#' @param repo_token The secret repo token for your repository,
+#' found at the bottom of your repository's page on Coveralls. This is useful
+#' if your job is running on a service Coveralls doesn't support out-of-the-box.
+#' If set to NULL, it is assumed that the job is running on travis-ci
 #' @param ... additional arguments passed to \code{\link{package_coverage}}
 #' @export
-coveralls <- function(path = ".", ...) {
+coveralls <- function(path = ".", repo_token = NULL, ...) {
   coveralls_url <- "https://coveralls.io/api/v1/jobs"
-  coverage <- to_coveralls(package_coverage(path, relative_path = TRUE, ...))
+  coverage <- to_coveralls(package_coverage(path, relative_path = TRUE, ...), repo_token = repo_token)
 
   name <- tempfile()
   con <- file(name)
@@ -14,7 +18,7 @@ coveralls <- function(path = ".", ...) {
   httr::content(httr::POST(coveralls_url, body = list(json_file = httr::upload_file(name))))
 }
 
-to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"), service_name = "travis-ci") {
+to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"), service_name = "travis-ci", repo_token = repo_token) {
   coverages <- per_line(x)
 
   coverage_names <- names(coverages)
@@ -40,10 +44,18 @@ to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"), servic
     SIMPLIFY = FALSE,
     USE.NAMES = FALSE)
 
-  jsonlite::toJSON(na = "null", list(
-    "service_job_id" = jsonlite::unbox(service_job_id),
-    "service_name" = jsonlite::unbox(service_name),
-    "source_files" = res))
+  payload <- if (is.null(repo_token)) {
+    list(
+      "service_job_id" = jsonlite::unbox(service_job_id),
+      "service_name" = jsonlite::unbox(service_name),
+      "source_files" = res)
+  } else {
+    list(
+      "repo_token" = jsonlite::unbox(repo_token),
+      "source_files" = res)
+  }
+
+  jsonlite::toJSON(na = "null", payload)
 }
 
 per_line <- function(x) {

--- a/R/coveralls.R
+++ b/R/coveralls.R
@@ -18,7 +18,7 @@ coveralls <- function(path = ".", repo_token = NULL, ...) {
   httr::content(httr::POST(coveralls_url, body = list(json_file = httr::upload_file(name))))
 }
 
-to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"), service_name = "travis-ci", repo_token = repo_token) {
+to_coveralls <- function(x, service_job_id = Sys.getenv("TRAVIS_JOB_ID"), service_name = "travis-ci", repo_token = NULL) {
   coverages <- per_line(x)
 
   coverage_names <- names(coverages)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ after_success:
   - Rscript -e 'library(covr);coveralls()'
 ```
 
+Alternatively, if you want to use another CI service, you can specify your
+secret repo token for the repository, found at the bottom of your
+repository's page on Coveralls. Your ```after_success``` would
+then look like this:
+
+```yml
+after_success:
+  - Rscript -e 'library(covr);coveralls(repo_token = "your_secret_token")'
+```
+
 Also you will need to turn on coveralls for your project at <https://coveralls.io/repos/new>.
 
 # Usage #

--- a/man/coveralls.Rd
+++ b/man/coveralls.Rd
@@ -4,10 +4,15 @@
 \alias{coveralls}
 \title{Run covr on a package and upload the result to coveralls}
 \usage{
-coveralls(path = ".", ...)
+coveralls(path = ".", repo_token = NULL, ...)
 }
 \arguments{
 \item{path}{file path to the package}
+
+\item{repo_token}{The secret repo token for your repository,
+found at the bottom of your repository's page on Coveralls. This is useful
+if your job is running on a service Coveralls doesn't support out-of-the-box.
+If set to NULL, it is assumed that the job is running on travis-ci}
 
 \item{...}{additional arguments passed to \code{\link{package_coverage}}}
 }

--- a/tests/testthat/test-coveralls.R
+++ b/tests/testthat/test-coveralls.R
@@ -19,3 +19,24 @@ test_that("coveralls generates a properly formatted json file", {
         NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1))
     )
 })
+
+test_that("coveralls can spawn a job using repo_token", {
+
+  with_mock(
+    `httr:::perform` = function(...) list(...),
+    `httr::content` = identity,
+    `httr::upload_file` = function(file) readChar(file, file.info(file)$size),
+
+    res <- coveralls("TestS4", repo_token="mytoken"),
+    json <<- jsonlite::fromJSON(res[[5]]$body$json_file),
+
+    expect_equal(nrow(json$source_files), 1),
+    expect_equal(json$service_name, NULL),
+    expect_equal(json$repo_token, "mytoken"),
+    expect_equal(json$source_files$name, "TestS4/R/TestS4.R"),
+    expect_equal(json$source_files$source, read_file("TestS4/R/TestS4.R")),
+    expect_equal(json$source_files$coverage[[1]],
+      c(NA, NA, 5, 2, 5, 3, 5, NA, NA, NA, NA, NA, NA, NA, NA, NA,
+        NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1))
+    )
+})


### PR DESCRIPTION
by specifying `repo-token`