### PR TITLE
URLs in description file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,6 +8,8 @@ Description: Track and report code coverage for your package and (optionally)
     amount of code being exercised by the tests.  It is an indirect measure of
     test quality. This package is compatible with any testing methodology or
     framework and tracks coverage of both R code and compiled C/C++/Fortran code.
+URL: https://github.com/jimhester/covr
+BugReports: https://github.com/jimhester/covr/issues
 Depends:
     R (>= 3.1.0),
     methods


### PR DESCRIPTION
This is In case you wanted your CRAN page to refer to your repo.  I noticed there wasn't a link.