### PR TITLE
update 'use_try' logic to line up with argument intent

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -110,8 +110,7 @@ function_coverage <- function(fun, ..., env = NULL, enc = parent.frame()) {
 #' @param exclude_end a search pattern to look for in the source to stop an exclude block.
 #' @param use_subprocess whether to run the code in a separate subprocess.
 #' Needed for compiled code and many packages using S4 classes.
-#' @param use_try whether to omit wrapping test evaluation in a \code{try} call;
-#' by default tests will be run within a \code{try} call
+#' @param use_try whether to wrap test evaluation in a \code{try} call; enabled by default
 #' @seealso exclusions
 #' @export
 package_coverage <- function(path = ".",
@@ -288,9 +287,9 @@ run_tests <- function(pkg, tmp_lib, dots, type, quiet, use_try=TRUE) {
         quote("library(methods)"),
         if (type == "test" && file.exists(testing_dir)) {
           if(isTRUE(use_try)) {
-            bquote(source_dir(path = .(testing_dir), env = .(env), quiet = .(quiet)))
-          } else {
             bquote(try(source_dir(path = .(testing_dir), env = .(env), quiet = .(quiet))))
+          } else {
+            bquote(source_dir(path = .(testing_dir), env = .(env), quiet = .(quiet)))
           }
         } else if (type == "vignette" && file.exists(vignette_dir)) {
           lapply(dir(vignette_dir, pattern = rex::rex(".", one_of("R", "r"), or("nw", "md")), full.names = TRUE),

--- a/man/package_coverage.Rd
+++ b/man/package_coverage.Rd
@@ -38,8 +38,7 @@ paths.}
 \item{use_subprocess}{whether to run the code in a separate subprocess.
 Needed for compiled code and many packages using S4 classes.}
 
-\item{use_try}{whether to omit wrapping test evaluation in a \code{try} call;
-by default tests will be run within a \code{try} call}
+\item{use_try}{whether to wrap test evaluation in a \code{try} call; enabled by default}
 }
 \description{
 Calculate test coverage for a package

--- a/tests/testthat/test-try.R
+++ b/tests/testthat/test-try.R
@@ -1,5 +1,5 @@
 context("use_try")
 test_that("package coverage exits prematurely when `use_try=FALSE`", {
-  expect_true(percent_coverage(package_coverage("TestUseTry", use_try = FALSE)) < 50)
-  expect_equal(percent_coverage(package_coverage("TestUseTry", use_try = TRUE)), 100)
+  expect_true(percent_coverage(package_coverage("TestUseTry", use_try = TRUE)) < 50)
+  expect_equal(percent_coverage(package_coverage("TestUseTry", use_try = FALSE)), 100)
 })


### PR DESCRIPTION
When changing from admittedly confusing 'no_try' to 'use_try', the
underlying logic needed to be negated as well to avoid a truly
confusing mess (which goes to highlight your point about avoiding
negative arguments to begin with...)