### PR TITLE
replaced the tryCatch() by a try() in try_unload because of potential…

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -315,7 +315,8 @@ run_tests <- function(pkg, tmp_lib, dots, type, quiet, use_try=TRUE) {
 }
 
 try_unload <- function(pkg) {
-  tryCatch(unloadNamespace(pkg), error = function(e) warning(e))
+  e <- try(unloadNamespace(pkg))
+  if (inherits(e, 'try-error')) warning(e)
 }
 
 process_examples <- function(pkg, lib = getwd(), quiet = TRUE) {


### PR DESCRIPTION
… problems with nested tryCatch() calls

cf http://stackoverflow.com/questions/33256075/odd-behaviour-of-nested-trycatch

When calling **package_coverage()** with a variant of mclapply which uses a tryCatch(), the **unloadNamespace(pkg)** fails (for good reason), but **try_unload()** fails to resume processing, so that the run_tests() function never returns the coverage results.