### PR TITLE
make it clear that when using coveralls travis.yml needs to install c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Alternatively you can upload your results to [Coveralls](https://coveralls.io/)
 using `coveralls()`.
 
 ```yml
+r_github_packages:
+  - jimhester/covr
+
 after_success:
   - Rscript -e 'covr::coveralls()'
 ```


### PR DESCRIPTION
…ovr package

When I first read the documentation, I skipped the subsection for Codecov because I'm using coveralls. I assumed that covr just gets installed by travis, just like the hadleyverse, since I didn't see it in the instructions for coveralls. Only after half an hour of not understanding why the tests aren't running, I re-read the full README and when I saw the codecov section I realized I need to add that line. I think it'd be useful to make it clear