### PR TITLE
minor typo in covr.R

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -284,7 +284,6 @@ run_tests <- function(pkg, tmp_lib, dots, type, quiet, use_try = TRUE) {
                              "--with-keep.source",
                              "--no-byte-compile",
                              "--no-test-load",
-                             "--no-multiarch",
                              "-l",
                              tmp_lib),
                   quiet = quiet)


### PR DESCRIPTION
the option --no-multiarch was there twice