### PR TITLE
NULL issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* `NULL` statements are analyzed for coverage (#156, @krlmlr).
+
 * Finer coverage analysis for braceless `if`, `while` and `for` statements (#154, @krlmlr).
 
 ## 1.3.0 ##

--- a/R/summary_functions.R
+++ b/R/summary_functions.R
@@ -28,6 +28,11 @@ tally_coverage <- function(x, by = c("line", "expression")) {
              return(df)
            }
 
+           # aggregate() can't cope with zero-length data frames anyway.
+           if (nrow(df) == 0L) {
+             return(NULL)
+           }
+
            # results with NA functions (such as from compiled code) are dropped
            # unless NA is a level.
            df$functions <- addNA(df$functions)
@@ -225,7 +230,7 @@ markers.data.frame <- function(x, type = "test") { # nolint
 expand_lines <- function(x) {
   repeats <- (x$last_line - x$first_line) + 1L
 
-  lines <- unlist(Map(seq, x$first_line, x$last_line))
+  lines <- unlist(Map(seq, x$first_line, x$last_line)) %||% integer()
 
   res <- x[rep(seq_len(NROW(x)), repeats), c("filename", "functions", "value")]
   res$line <- lines

--- a/R/trace_calls.R
+++ b/R/trace_calls.R
@@ -16,11 +16,11 @@ trace_calls <- function (x, parent_functions = NULL, parent_ref = NULL) {
   }
 
   if (is.atomic(x) || is.name(x)) {
-    if (length(x) == 0 || is.null(parent_ref)) {
+    if (is.null(parent_ref)) {
       x
     }
     else {
-      if ((!is.symbol(x) && is.na(x)) || as.character(x) == "{") { # nolint
+      if (!is.null(x) && ((!is.symbol(x) && is.na(x)) || as.character(x) == "{")) { # nolint
         x
       } else {
         key <- new_counter(parent_ref, parent_functions) # nolint

--- a/R/trace_calls.R
+++ b/R/trace_calls.R
@@ -20,7 +20,7 @@ trace_calls <- function (x, parent_functions = NULL, parent_ref = NULL) {
       x
     }
     else {
-      if (!is.null(x) && ((!is.symbol(x) && is.na(x)) || as.character(x) == "{")) { # nolint
+      if (is_na(x) || is_brace(x)) {
         x
       } else {
         key <- new_counter(parent_ref, parent_functions) # nolint

--- a/R/trace_calls.R
+++ b/R/trace_calls.R
@@ -46,7 +46,7 @@ trace_calls <- function (x, parent_functions = NULL, parent_ref = NULL) {
   else if (is.function(x)) {
     fun_body <- body(x)
 
-    if (!is.null(fun_body) && !is.null(attr(x, "srcref")) &&
+    if (!is.null(attr(x, "srcref")) &&
        (is.symbol(fun_body) || !identical(fun_body[[1]], as.name("{")))) {
       src_ref <- attr(x, "srcref")
       key <- new_counter(src_ref, parent_functions)

--- a/R/utils.R
+++ b/R/utils.R
@@ -298,6 +298,14 @@ setdiff.data.frame <- function(x, y,
 
 `%==%` <- function(x, y) identical(x, y)
 
+is_na <- function(x) {
+  !is.null(x) && !is.symbol(x) && is.na(x)
+}
+
+is_brace <- function(x) {
+  !is.null(x) && as.character(x) == "{"
+}
+
 modify_name <- function(expr, old, new) {
   replace <- function(e)
     if (is.name(e) && identical(e, as.name(old))) e <- as.name(new)

--- a/tests/testthat/test-null.R
+++ b/tests/testthat/test-null.R
@@ -16,11 +16,13 @@ test_that("coverage of functions with NULL constructs", {
   }
 
   cv1 <- function_coverage(f1, f1())
-  expect_error(expect_equal(percent_coverage(cv1), 100), NA)
+  expect_equal(percent_coverage(cv1), 100)
   cv2 <- function_coverage(f2, f2())
-  expect_error(expect_equal(percent_coverage(cv2), 100), NA)
+  expect_equal(percent_coverage(cv2), 100)
   cv3 <- function_coverage(f3, f3())
-  expect_error(expect_equal(percent_coverage(cv3), 66.666666), NA)
+  # Will change with #154
+  expect_equal(percent_coverage(cv3), 200 / 3)
   cv4 <- function_coverage(f4, f4())
-  expect_error(expect_equal(percent_coverage(cv4), 50), NA)
+  # Will change with #154
+  expect_equal(percent_coverage(cv4), 100)
 })

--- a/tests/testthat/test-null.R
+++ b/tests/testthat/test-null.R
@@ -20,9 +20,7 @@ test_that("coverage of functions with NULL constructs", {
   cv2 <- function_coverage(f2, f2())
   expect_equal(percent_coverage(cv2), 100)
   cv3 <- function_coverage(f3, f3())
-  # Will change with #154
-  expect_equal(percent_coverage(cv3), 200 / 3)
+  expect_equal(percent_coverage(cv3), 50)
   cv4 <- function_coverage(f4, f4())
-  # Will change with #154
-  expect_equal(percent_coverage(cv4), 100)
+  expect_equal(percent_coverage(cv4), 50)
 })

--- a/tests/testthat/test-null.R
+++ b/tests/testthat/test-null.R
@@ -1,0 +1,26 @@
+context("NULL")
+
+test_that("coverage of functions with NULL constructs", {
+  f1 <- function() NULL
+  f2 <- function() {
+    NULL
+  }
+  f3 <- function() {
+    if (FALSE) {
+      NULL
+    }
+  }
+  f4 <- function() {
+    if (FALSE)
+      NULL
+  }
+
+  cv1 <- function_coverage(f1, f1())
+  expect_error(expect_equal(percent_coverage(cv1), 100), NA)
+  cv2 <- function_coverage(f2, f2())
+  expect_error(expect_equal(percent_coverage(cv2), 100), NA)
+  cv3 <- function_coverage(f3, f3())
+  expect_error(expect_equal(percent_coverage(cv3), 66.666666), NA)
+  cv4 <- function_coverage(f4, f4())
+  expect_error(expect_equal(percent_coverage(cv4), 50), NA)
+})

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -2,8 +2,8 @@ context("summary_functions")
 
 test_that("Summary gives 20% coverage and four lines with zero coverage", {
   cv <- package_coverage("TestSummary")
-  expect_equal(percent_coverage(cv), 20)
-  expect_equal(nrow(zero_coverage(cv)), 4)
+  expect_equal(percent_coverage(cv), 40)
+  expect_equal(nrow(zero_coverage(cv)), 3)
 })
 
 test_that("percent_coverage", {

--- a/tests/testthat/test-trace_calls.R
+++ b/tests/testthat/test-trace_calls.R
@@ -95,5 +95,5 @@ test_that("functions with NULL bodies are traced correctly", {
 
   fun <- function() NULL
 
-  expect_equal(trace_calls(fun), fun)
+  expect_null(trace_calls(fun)())
 })


### PR DESCRIPTION
Currently, NULL literals seem to be completely ignored for coverage. A few tweaks to trace_calls() do the trick.

Also addresses errors that occur when coverage result is empty.

Test will have to be amended if #154 is merged.