### PR TITLE
Sort child parse data

### DIFF
--- a/R/parse_data.R
+++ b/R/parse_data.R
@@ -63,6 +63,7 @@ impute_srcref <- function(x, parent_ref) {
   stopifnot(length(pd_expr_idx) == 1L)
   expr_id <- pd$id[pd_expr_idx]
   pd_child <- pd[pd$parent == expr_id, ]
+  pd_child <- pd_child[order(pd_child$line1, pd_child$col1), ]
 
   line_offset <- parent_ref[[7L]] - parent_ref[[1L]]
 

--- a/R/summary_functions.R
+++ b/R/summary_functions.R
@@ -79,7 +79,21 @@ tally_coverage <- function(x, by = c("line", "expression")) {
 #' @export
 zero_coverage <- function(x, ...) {
   coverage_data <- tally_coverage(x, ...)
-  coverage_data <- coverage_data[coverage_data$value == 0, ]
+  coverage_data <- coverage_data[coverage_data$value == 0, , drop = FALSE]
+
+  res <- coverage_data[
+    # need to use %in% rather than explicit indexing because
+    # tally_coverage returns a df without the columns if
+    # by is equal to "line"
+    colnames(coverage_data) %in%
+      c("filename",
+        "functions",
+        "line",
+        "first_line",
+        "last_line",
+        "first_column",
+        "last_column",
+        "value")]
 
   if (getOption("covr.rstudio_source_markers", TRUE) &&
       rstudioapi::hasFun("sourceMarkers")) {
@@ -89,21 +103,9 @@ zero_coverage <- function(x, ...) {
                         markers = markers,
                         basePath = attr(x, "package")$path,
                         autoSelect = "first")
-    invisible(x)
+    invisible(res)
   } else {
-
-    coverage_data[
-                  # need to use %in% rather than explicit indexing because
-                  # tally_coverage returns a df without the columns if
-                  # by is equal to "line"
-                  colnames(coverage_data) %in%
-                    c("filename",
-                      "functions",
-                      "first_line",
-                      "last_line",
-                      "first_column",
-                      "last_column",
-                      "value")]
+    res
   }
 }
 
@@ -216,7 +218,7 @@ markers.data.frame <- function(x, type = "test") { # nolint
       message = sprintf("No %s Coverage!", to_title(type))
     )},
     x$filename,
-    x$first_line,
+    x$first_line %||% x$line,
     x$first_column %||% rep(list(NULL), NROW(x)),
     USE.NAMES = FALSE)
 }

--- a/tests/testthat/test-braceless.R
+++ b/tests/testthat/test-braceless.R
@@ -13,7 +13,7 @@ test_that("if", {
   expect_equal(percent_coverage(function_coverage(f, f(TRUE), f(FALSE))), 100)
 })
 
-test_that("if", {
+test_that("if complex", {
   f <- function(x) {
     if (x)
       x <- TRUE

--- a/tests/testthat/test-braceless.R
+++ b/tests/testthat/test-braceless.R
@@ -2,26 +2,34 @@ context("braceless")
 
 test_that("if", {
   f <- function(x) {
+    if (FALSE)
+      FALSE # never covered, used as anchor
     if (x)
       TRUE
     else
       FALSE
   }
 
-  expect_equal(percent_coverage(function_coverage(f, f(TRUE))), 50)
-  expect_equal(percent_coverage(function_coverage(f, f(FALSE))), 75)
-  expect_equal(percent_coverage(function_coverage(f, f(TRUE), f(FALSE))), 100)
+  expect_equal(diff(zero_coverage(function_coverage(f, f(TRUE)))$line),
+               c(3, 1))
+  expect_equal(diff(zero_coverage(function_coverage(f, f(FALSE)))$line), 2)
+  expect_equal(length(zero_coverage(function_coverage(f, f(TRUE), f(FALSE)))$line),
+               1)
 })
 
 test_that("if complex", {
   f <- function(x) {
+    if (FALSE)
+      FALSE # never covered, used as anchor
     if (x)
       x <- TRUE
     else
       x <- FALSE
   }
 
-  expect_equal(percent_coverage(function_coverage(f, f(TRUE))), 50)
-  expect_equal(percent_coverage(function_coverage(f, f(FALSE))), 75)
-  expect_equal(percent_coverage(function_coverage(f, f(TRUE), f(FALSE))), 100)
+  expect_equal(diff(zero_coverage(function_coverage(f, f(TRUE)))$line),
+               c(3, 1))
+  expect_equal(diff(zero_coverage(function_coverage(f, f(FALSE)))$line), 2)
+  expect_equal(length(zero_coverage(function_coverage(f, f(TRUE), f(FALSE)))$line),
+               1)
 })

--- a/tests/testthat/test-braceless.R
+++ b/tests/testthat/test-braceless.R
@@ -1,0 +1,27 @@
+context("braceless")
+
+test_that("if", {
+  f <- function(x) {
+    if (x)
+      TRUE
+    else
+      FALSE
+  }
+
+  expect_equal(percent_coverage(function_coverage(f, f(TRUE))), 50)
+  expect_equal(percent_coverage(function_coverage(f, f(FALSE))), 75)
+  expect_equal(percent_coverage(function_coverage(f, f(TRUE), f(FALSE))), 100)
+})
+
+test_that("if", {
+  f <- function(x) {
+    if (x)
+      x <- TRUE
+    else
+      x <- FALSE
+  }
+
+  expect_equal(percent_coverage(function_coverage(f, f(TRUE))), 50)
+  expect_equal(percent_coverage(function_coverage(f, f(FALSE))), 75)
+  expect_equal(percent_coverage(function_coverage(f, f(TRUE), f(FALSE))), 100)
+})

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -2,8 +2,8 @@ context("summary_functions")
 
 test_that("Summary gives 20% coverage and four lines with zero coverage", {
   cv <- package_coverage("TestSummary")
-  expect_equal(percent_coverage(cv), 20)
-  expect_equal(nrow(zero_coverage(cv)), 4)
+  expect_equal(percent_coverage(cv), 40)
+  expect_equal(nrow(zero_coverage(cv)), 3)
 })
 
 test_that("percent_coverage", {


### PR DESCRIPTION
in `impute_srcref()`, necessary for complex substatements. With tests.

Fixes #161.