### PR TITLE
Add in GitLab-CI support

### DIFF
--- a/R/codecov.R
+++ b/R/codecov.R
@@ -130,6 +130,21 @@ codecov <- function(...,
                           repo = Sys.getenv("WERCKER_GIT_REPOSITORY"),
                           commit = commit %||% Sys.getenv("WERCKER_GIT_COMMIT"))
   # ---------
+  # GitLab-CI
+  # ---------
+  } else if (Sys.getenv("CI") == "true" && Sys.getenv("CI_SERVER_NAME") == "GitLab CI") {
+    # http://docs.gitlab.com/ce/ci/variables/README.html
+    slug <- Sys.getenv("CI_BUILD_REPO")
+    slug <- sub('\\.git$', '', slug)
+    slug <- strsplit(slug, '/', fixed = TRUE)[[1]][4:5]
+    slug <- paste0(slug, collapse = '/')
+    codecov_url <- paste0(base_url, "/upload/v2") # nolint
+    codecov_query <- list(service = "gitlab",
+                          branch = branch %||% Sys.getenv("CI_BUILD_REF_NAME"),
+                          build = Sys.getenv("CI_BUILD_ID"),
+                          slug = slug,
+                          commit = commit %||% Sys.getenv("CI_BUILD_REF"))
+  # ---------
   # Local GIT
   # ---------
   } else {

--- a/R/codecov.R
+++ b/R/codecov.R
@@ -144,8 +144,10 @@ codecov <- function(...,
                           build = Sys.getenv("CI_BUILD_ID"),
                           slug = slug,
                           commit = commit %||% Sys.getenv("CI_BUILD_REF"))
+    if (! quiet) {
       message('Using GitLab-CI code...')
       print(str(codecov_query))
+    }
   # ---------
   # Local GIT
   # ---------
@@ -160,8 +162,7 @@ codecov <- function(...,
     codecov_query$token <- token
   }
 
-    coverage_json <- to_codecov(coverage)
-    print(str(coverage_json))
+  coverage_json <- to_codecov(coverage)
 
   httr::content(httr::POST(url = codecov_url, query = codecov_query, body = coverage_json, encode = "json"))
 }

--- a/R/codecov.R
+++ b/R/codecov.R
@@ -144,6 +144,8 @@ codecov <- function(...,
                           build = Sys.getenv("CI_BUILD_ID"),
                           slug = slug,
                           commit = commit %||% Sys.getenv("CI_BUILD_REF"))
+      message('Using GitLab-CI code...')
+      print(str(codecov_query))
   # ---------
   # Local GIT
   # ---------
@@ -158,7 +160,8 @@ codecov <- function(...,
     codecov_query$token <- token
   }
 
-  coverage_json <- to_codecov(coverage)
+    coverage_json <- to_codecov(coverage)
+    print(str(coverage_json))
 
   httr::content(httr::POST(url = codecov_url, query = codecov_query, body = coverage_json, encode = "json"))
 }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ without needing `CODECOV_TOKEN`).
 - [drone.io](https://drone.io)
 - [AppVeyor\*](http://www.appveyor.com)
 - [Wercker](http://wercker.com)
+- [GitLab-CI](https://about.gitlab.com/gitlab-ci/)
 
 You will also need to enable the repository on [Codecov](https://codecov.io/).
 


### PR DESCRIPTION
Added support for uploading code coverage statistics to https://codecov.io when using GitLab-CI continuous integration server. The generic `git` codepath in the `codecov` function would upload statistics to the codecov server, but it wasn't then associated with the correct code branch -- always being `HEAD` rather than `master` or another branch. The relevant information was extracted from GitLab-CI environment variables (http://docs.gitlab.com/ce/ci/variables/README.html) using the official bash script from codecov as a template (https://codecov.io/bash).