### PR TITLE
Removed useless and harmful on.exit(clear_counters()) call in package_coverage()

### DIFF
--- a/R/covr.R
+++ b/R/covr.R
@@ -171,8 +171,6 @@ package_coverage <- function(path = ".",
     return(res)
   }
 
-  on.exit(clear_counters())
-
   tmp_lib <- temp_file("R_LIBS")
   dir.create(tmp_lib)
 


### PR DESCRIPTION
 cf https://github.com/jimhester/covr/issues/200
