### PR TITLE
AppVeyor expects its service name all lowercase

### DIFF
--- a/R/codecov.R
+++ b/R/codecov.R
@@ -113,7 +113,7 @@ codecov <- function(...,
     # http://www.appveyor.com/docs/environment-variables
     codecov_url <- paste0(base_url, "/upload/v2") # nolint
     name_info <- strsplit(Sys.getenv("APPVEYOR_REPO_NAME"), "/")[[1]]
-    codecov_query <- list(service = "AppVeyor",
+    codecov_query <- list(service = "appveyor",
                           branch = branch %||% Sys.getenv("APPVEYOR_REPO_BRANCH"),
                           build = Sys.getenv("APPVEYOR_BUILD_NUMBER"),
                           owner = name_info[1],

--- a/tests/testthat/test-codecov.R
+++ b/tests/testthat/test-codecov.R
@@ -326,7 +326,7 @@ test_that("it works with AppVeyor", {
 
       res <- codecov(coverage = cov),
 
-      expect_match(res$query$service, "AppVeyor"),
+      expect_match(res$query$service, "appveyor"),
       expect_match(res$query$branch, "master"),
       expect_match(res$query$build, "5"),
       expect_match(res$query$owner, "tester"),


### PR DESCRIPTION
see https://codecov.io/bash VERSION="e7c0c15"