### PR TITLE
Fixes for R_KEEP_PKG_SOURCE=yes.

### DIFF
--- a/tests/testthat/test-R6.R
+++ b/tests/testthat/test-R6.R
@@ -3,6 +3,7 @@ context("R6")
 test_that("R6 methods coverage is reported", {
   cov <- as.data.frame(package_coverage("TestR6"))
 
+  cov <- cov[cov$filename == "R/TestR6.R",]
   expect_equal(cov$value, c(5, 2, 3, 1, 1))
   expect_equal(cov$first_line, c(5, 6, 8, 16, 19))
   expect_equal(cov$last_line, c(5, 6, 8, 16, 19))

--- a/tests/testthat/test-RC.R
+++ b/tests/testthat/test-RC.R
@@ -2,6 +2,7 @@ context("RC")
 test_that("RC methods coverage is reported", {
   cov <- as.data.frame(package_coverage("TestRC"))
 
+  cov <- cov[cov$filename == "R/TestRC.R",]
   expect_equal(cov$value, c(5, 2, 3, 1, 1))
   expect_equal(cov$first_line, c(5, 6, 8, 17, 20))
   expect_equal(cov$last_line, c(5, 6, 8, 17, 20))

--- a/tests/testthat/test-S4.R
+++ b/tests/testthat/test-S4.R
@@ -2,6 +2,7 @@ context("S4")
 test_that("S4 methods coverage is reported", {
   cov <- as.data.frame(package_coverage("TestS4"))
 
+  cov <- cov[cov$filename == "R/TestS4.R",]
   expect_equal(cov$first_line, c(7, 8, 10, 25, 31, 37))
 
   expect_equal(cov$value, c(5, 2, 3, 1, 1, 1))

--- a/tests/testthat/test-codecov.R
+++ b/tests/testthat/test-codecov.R
@@ -59,9 +59,10 @@ test_that("it generates a properly formatted json file", {
 
       res <- codecov(coverage = cov),
       json <- jsonlite::fromJSON(res$body),
+      fidx <- seq_len(length(json$files$name))[json$files$name == "R/TestS4.R"],
 
-      expect_match(json$files$name, "R/TestS4.R"),
-      expect_equal(json$files$coverage[[1]],
+      expect_equal(length(fidx), 1),
+      expect_equal(json$files$coverage[[fidx]],
         c(NA, NA, NA, NA, NA, NA, NA, 5, 2, NA, 3, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,
           NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA)
         ),

--- a/tests/testthat/test-corner-cases.R
+++ b/tests/testthat/test-corner-cases.R
@@ -5,5 +5,8 @@ test_that("corner-cases are handled as expected", {
     cov <- file_coverage("corner-cases.R", "corner-cases-test.R")
   }))
 
-  expect_equal(as.data.frame(cov), readRDS("corner-cases.Rds"))
+  cov <- as.data.frame(cov)
+  cov <- cov[cov$filename == "corner-cases.R",]
+  rownames(cov) <- NULL # get default row names after removing some files
+  expect_equal(cov, readRDS("corner-cases.Rds"))
 })

--- a/tests/testthat/test-coveralls.R
+++ b/tests/testthat/test-coveralls.R
@@ -62,11 +62,13 @@ test_that("coveralls generates a properly formatted json file", {
       res <- coveralls(coverage = cov),
       json <- jsonlite::fromJSON(res$body$json_file),
 
-      expect_equal(nrow(json$source_files), 1),
+      expect_true(nrow(json$source_files) >= 1),
+      fidx <-seq_len(length(json$source_files$name))[basename(json$source_files$name)=="TestS4.R"],
+      expect_equal(length(fidx), 1),
       expect_equal(json$service_name, "fakeci"),
-      expect_match(json$source_files$name, rex::rex("R", one_of("/", "\\"), "TestS4.R")),
-      expect_equal(json$source_files$source, read_file("TestS4/R/TestS4.R")),
-      expect_equal(json$source_files$coverage[[1]],
+      expect_match(json$source_files$name[[fidx]], rex::rex("R", one_of("/", "\\"), "TestS4.R")),
+      expect_equal(json$source_files$source[[fidx]], read_file("TestS4/R/TestS4.R")),
+      expect_equal(json$source_files$coverage[[fidx]],
         c(NA, NA, NA, NA, NA, NA, 5, 2, NA, 3, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,
           NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA))
     )
@@ -86,12 +88,14 @@ test_that("coveralls can spawn a job using repo_token", {
       json <- jsonlite::fromJSON(res$body$json_file),
 
       expect_equal(is.null(json$git), FALSE),
-      expect_equal(nrow(json$source_files), 1),
+      expect_true(nrow(json$source_files) >= 1),
+      fidx <-seq_len(length(json$source_files$name))[basename(json$source_files$name)=="TestS4.R"],
+      expect_equal(length(fidx), 1),
       expect_equal(json$service_name, NULL),
       expect_equal(json$repo_token, "mytoken"),
-      expect_match(json$source_files$name, rex::rex("R", one_of("/", "\\"), "TestS4.R")),
-      expect_equal(json$source_files$source, read_file("TestS4/R/TestS4.R")),
-      expect_equal(json$source_files$coverage[[1]],
+      expect_match(json$source_files$name[[fidx]], rex::rex("R", one_of("/", "\\"), "TestS4.R")),
+      expect_equal(json$source_files$source[[fidx]], read_file("TestS4/R/TestS4.R")),
+      expect_equal(json$source_files$coverage[[fidx]],
         c(NA, NA, NA, NA, NA, NA, 5, 2, NA, 3, NA, NA, NA, NA, NA, NA, NA, NA, NA, NA,
           NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA, NA, NA, NA, NA, 1, NA))
     )


### PR DESCRIPTION
It turns out that covr tests fail when packages are built with R_KEEP_PKG_SOURCE=yes, because the coverages obtained include also source line information from unexpected packages, such as from the R6 implementation. This patch fixes the covr tests to be robust against this, so that they work both with and without source references for packages.