### PR TITLE
MEMORY: More memory efficient loading and merging of trace files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 2.2.2
+Version: 2.2.2-9000
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,4 +61,4 @@ Suggests:
 License: GPL-3
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 6.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 2.2.2-9000
+Version: 2.2.2.9000
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2.2.2-9000 ##
+* Made the gather-and-merge-results step at the end of package_coverage() more memory efficient (#226, @HenrikBengtsson).
+
 ## 2.2.2 ##
 * `filter_not_package_files()` now works if a source reference does not have a filename (#254, @hughjonesd).
 * Fix test broken with xml2 v1.1.0

--- a/R/covr.R
+++ b/R/covr.R
@@ -292,7 +292,7 @@ package_coverage <- function(path = ".",
 
   # read tracing files
   trace_files <- list.files(path = tmp_lib, pattern = "^covr_trace_[^/]+$", full.names = TRUE)
-  coverage <- merge_coverage_files(trace_files)
+  coverage <- merge_coverage(trace_files)
   coverage <- structure(c(coverage, run_gcov(pkg$path, quiet = quiet)),
     class = "coverage",
     package = pkg,
@@ -319,32 +319,10 @@ show_failures <- function(dir) {
   }
 }
 
-# merge multiple coverage outputs together Assumes the order of coverage lines
+# merge multiple coverage files together. Assumes the order of coverage lines
 # is the same in each object, this should always be the case if the objects are
 # from the same initial library.
-merge_coverage <- function(...) {
-  objs <- as.list(...)
-  if (length(objs) == 0) {
-    return()
-  }
-
-  x <- objs[[1]]
-  others <- objs[-1]
-
-  if (getRversion() < "3.2.0") {
-    lengths <- function(x, ...) viapply(x, length)
-  }
-  stopifnot(all(lengths(others) == length(x)))
-
-  for (y in others) {
-    for (i in seq_along(x)) {
-      x[[i]]$value <- x[[i]]$value + y[[i]]$value
-    }
-  }
-  x
-}
-
-merge_coverage_files <- function(files) {
+merge_coverage <- function(files) {
   nfiles <- length(files)
   if (nfiles == 0) {
     return()
@@ -365,7 +343,7 @@ merge_coverage_files <- function(files) {
     }
     y <- NULL
   }
-  
+ 
   x
 }
 

--- a/R/covr.R
+++ b/R/covr.R
@@ -292,7 +292,7 @@ package_coverage <- function(path = ".",
 
   # read tracing files
   trace_files <- list.files(path = tmp_lib, pattern = "^covr_trace_[^/]+$", full.names = TRUE)
-  coverage <- merge_coverage(lapply(trace_files, function(x) as.list(readRDS(x))))
+  coverage <- merge_coverage_files(trace_files)
   coverage <- structure(c(coverage, run_gcov(pkg$path, quiet = quiet)),
     class = "coverage",
     package = pkg,
@@ -341,6 +341,31 @@ merge_coverage <- function(...) {
       x[[i]]$value <- x[[i]]$value + y[[i]]$value
     }
   }
+  x
+}
+
+merge_coverage_files <- function(files) {
+  nfiles <- length(files)
+  if (nfiles == 0) {
+    return()
+  }
+
+  x <- readRDS(files[1])
+  x <- as.list(x)
+  if (nfiles == 1) {
+    return(x)
+  }
+
+  names <- names(x)
+  for (i in 2:nfiles) {
+    y <- readRDS(files[i])
+    stopifnot(identical(names(y), names))
+    for (name in names) {
+      x[[name]]$value <- x[[name]]$value + y[[name]]$value
+    }
+    y <- NULL
+  }
+  
   x
 }
 


### PR DESCRIPTION
`package_coverage()` now loads and merges trace files one by one, such that the memory footprint is O(1).  Previously, all n trace files were loaded and then merged, which had a memory footprint of O(n).

I added a new `merge_coverage_files()` and kept the `merge_coverage()` because I don't know if the latter is meant to be used elsewhere.

Background: This solves a problem I had on Travis CI where I most likely ran out of memory at the end of `package_coverage()` causing Travis to kill my covr jobs, e.g. https://travis-ci.org/HenrikBengtsson/future/jobs/234566258#L806.