### PR TITLE
preserve paths in gcov output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 * Improve behavior of `switch` coverage, it now supports default values and
   fall through properly.
 
+* Add `-p` flag to gcov command to preserve file paths. Fixes a bug where
+  gcov output didn't get reported when multiple compiled source files had
+  the same name (#271, @patperry)
+
 ## 3.0.0 ##
 * The covr license has been changed to GPL-3.
 * Set environment variable `R_COVR=true` when covr is running (#236, #268).

--- a/R/compiled.R
+++ b/R/compiled.R
@@ -64,7 +64,7 @@ run_gcov <- function(path, quiet = TRUE,
   withr::with_dir(src_path, {
     run_gcov <- function(src) {
       system_check(gcov_path,
-        args = c(gcov_args, src, "-o", dirname(src[[1]])),
+        args = c(gcov_args, src, "-p", "-o", dirname(src[[1]])),
         quiet = quiet, echo = !quiet)
     }
     tapply(gcov_inputs, dirname(gcov_inputs), run_gcov)


### PR DESCRIPTION
I have a project with two C files having the same name, but in different directories. Without the "-p" flag, gcov will try to use the same file name for both `.gcov` files, clobbering one of the reports.

This patch adds the "-p" flag to gcov to preserve the file names in the reports. I've tested this on MacOS and Linux (Travis CI).

---

More info: the project is https://github.com/patperry/r-corpus
One instance of a name clash in that project are the files

```
src/termset.c
src/corpus/src/termset.c
```